### PR TITLE
Set listFiles resolvePaths to true

### DIFF
--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -46,7 +46,11 @@ export async function generateVeturFiles(
   const inputIsFile = ['.vue', '.jsx', '.tsx'].some((fileType) => inputPath.endsWith(fileType))
   const allFiles = inputIsFile
     ? [inputPath]
-    : await listFiles(inputPath, { regexFilter: /\.vue|\.jsx|\.tsx/, recursive })
+    : await listFiles(inputPath, {
+        regexFilter: /\.vue|\.jsx|\.tsx/,
+        recursive,
+        resolvePaths: true,
+      })
   const attributes = await vueFilePathsToVeturJsonData(allFiles, 'attributes')
   const tags = await vueFilePathsToVeturJsonData(allFiles, 'tags')
   await writeVeturFiles(outputPath, attributes, tags)


### PR DESCRIPTION
Setting `resolvePath` fixes https://github.com/CyCraft/vue-intellisense/issues/6 and probably also https://github.com/CyCraft/vue-intellisense/issues/5 

removing `resolvePath` logic completely would break `listFilesRecursively` so manually setting it there looks like a valid solution to me