### PR TITLE
refactor: make listFilesRecursively go beyond 1 depth

### DIFF
--- a/packages/scripts/src/listFiles.ts
+++ b/packages/scripts/src/listFiles.ts
@@ -18,7 +18,7 @@ async function listFilesRecursively(folderPath: string): Promise<string[]> {
   const files = await Promise.all(
     dirents.map((dirent: any) => {
       const res = resolve(folderPath, dirent.name)
-      return dirent.isDirectory() ? listFiles(res) : res
+      return dirent.isDirectory() ? listFilesRecursively(res) : res
     })
   )
   const allFiles = Array.prototype.concat(...files)


### PR DESCRIPTION
**Background**

Currently the `--recursive` option is not really recursive. It just goes 1-level deeper.

In my case, I have a modularized project structure (see below).

Because `--recursive` goes only 1 level deep, I cannot generate vetur data for all components in a single command, because that will search only `src/modules` and its direct children.

Command I used:

`vue-int --input /src/modules --output vetur --recursive`

Folder structure:

```
src
└─ modules/
    ├─ moduleA/
    |   └─ components/
    |       ├── ComponentAA.vue
    |       ├── ComponentAB.vue
    |       ...
    ├─ moduleB/
    |   └─ components/
    |       ├── ComponentBA.vue
    |       ├── ComponentBB.vue
    ...     ...
```

**Changes**

This changes allows to search for Vue files deeper than single level.