### PR TITLE
Fix match file extensions only

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-intellisense/scripts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "main": "dist/index.esm.js",
   "module": "dist/index.esm.js",

--- a/packages/scripts/src/index.ts
+++ b/packages/scripts/src/index.ts
@@ -54,7 +54,7 @@ export async function generateVeturFiles(
   const allFiles = inputIsFile
     ? [inputPath]
     : await listFiles(inputPath, {
-        regexFilter: /\.vue|\.jsx|\.tsx/,
+        regexFilter: /\.vue$|\.jsx$|\.tsx$/,
         recursive,
         resolvePaths: true,
       })

--- a/packages/vue-intellisense/package.json
+++ b/packages/vue-intellisense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-intellisense",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "A CLI tool to help enabling IntelliSense on your Vue components",
   "author": "Luca Ban - Mesqueeb",
@@ -24,7 +24,7 @@
   },
   "gitHead": "7a52c73677fc5550368eb358a9775aea3fc69e0e",
   "dependencies": {
-    "@vue-intellisense/scripts": "^1.0.1",
+    "@vue-intellisense/scripts": "^1.0.2",
     "case-anything": "^2.1.10",
     "chalk": "^5.0.0",
     "is-what": "^4.1.7",


### PR DESCRIPTION
Hey @mesqueeb!

I recently added a few new non-js files to my repo, in this case some jest snapshots with the filename pattern `component.js.vue3.snap`.
intellisense tries to generate info for these, but surely it doesn't work because it's neither JS nor vue.
I found the problem, it's that the regex filter during file search matches anywhere in the file and not just the extension. In my case, the filenames contain `.vue` in the middle and are matched.
The fix is just one line making sure the regex works correctly 🙂 
I also bumped the package versions using `npm run publish`.

Let me know what you think and if I can improve something.

Do you think we can get a new version published?